### PR TITLE
Fix case where EAN checksum is 0

### DIFF
--- a/lib/EAN.js
+++ b/lib/EAN.js
@@ -31,7 +31,14 @@ bardcode.encodeEAN = function(text) {
         sum += weight * n;
     }
 
-    var checksum = 10 - sum % 10;
+    // This could probably be achieved with a modulo and a check for 10 to wrap.
+    // However this implementation was lifted from the GS1 website:
+    // http://www.gs1.org/check-digit-calculator and is therefore guaranteed correct.
+    var closest = Math.round(sum / 10) * 10;
+    var checksum = closest - sum;
+    if (checksum < 0) {
+        checksum = (closest + 10) - sum;
+    }
     text += checksum;
 
     var outlist = [];

--- a/test/tests.js
+++ b/test/tests.js
@@ -315,6 +315,11 @@ if (Meteor.isServer) {
         test.equal(encodeData.checksum, 1);
     });
 
+    Tinytest.add("EAN - checksum(\"846823000342\") == 0", function(test) {
+        var encodeData = bardcode.encodeEAN("846823000342");
+        test.equal(encodeData.checksum, 0);
+    });
+
     Tinytest.add("EAN - checksum(\"9638507\") == 4", function(test) {
         var encodeData = bardcode.encodeEAN("9638507");
         test.equal(encodeData.checksum, 4);


### PR DESCRIPTION
Right now it gives an error:

> Error: Don't know how to make EAN with that length.
>    at Object.bardcode.encodeEAN (packages/froatsnook:bardcode/lib/EAN.js:79:1)

This is because, if `sum` is a multiple of 10, `10 - sum % 10` comes out to be `10` which then gets appended on to produce a barcode of length 14.

This PR replaced the modulo calculation with a more complex algorithm which was taken from the GS1's checksum calculator.
